### PR TITLE
Split "build" from "exec" phases in bin/test

### DIFF
--- a/bin/go_linux_arm_exec
+++ b/bin/go_linux_arm_exec
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+local_binary="${1?no package name provided}"
+shift
+
+remote_binary="$(basename "$local_binary").$USER"
+
+echo "Copying $remote_binary..."
+gzip -c "$local_binary" | sudo -u pi -- ssh pi "
+	gzip -d >$remote_binary &&
+	chmod +x $remote_binary &&
+	echo 'Starting ${remote_binary}...' &&
+	./$remote_binary $@
+	exit # somehow necessary to see an error message (e.g. killed by SEGV)
+"

--- a/bin/test
+++ b/bin/test
@@ -2,28 +2,13 @@
 
 set -e
 
-: ${1?no package name provided}
+mypath="$(dirname $0)"
 
-local_binary=$(mktemp --tmpdir -- "build-upload.$(basename $1).XXXXXXXXX")
-trap 'rm -f "$local_binary"' EXIT
-
-repo=$(basename $(git rev-parse --show-toplevel))
-remote_binary="$repo/$(basename "$1" .go).$USER"
-
-echo "[1/3] Building ${remote_binary}..."
 # TODO: use arm-linux-gnueabihf-gcc (note the 'hf'), take CGO_CFLAGS flags from
 # $ gcc -mcpu=native -march=native -Q --help=target
 # Currently it's '-march=armv6zk -mcpu=arm1176jz-s -mfloat-abi=hard -mfpu=vfp'
 # but dies randomly with SIGSEGV or SIGILL.
-CGO_ENABLED=1 CC=arm-linux-gnueabi-gcc \
-	GOOS=linux GOARCH=arm go build -o "$local_binary" "$1"
-shift
 
-echo "[2/3] Copying $remote_binary..."
-gzip -c "$local_binary" | sudo -u pi -- ssh pi "
-	gzip -d >$remote_binary &&
-	chmod +x $remote_binary &&
-	echo '[3/3] Starting ${remote_binary}...' &&
-	$remote_binary $@
-	exit # somehow necessary to see an error message (e.g. killed by SEGV)
-"
+# 'go run' will be looking for go_${GOOS}_${GOARCH}_exec in $PATH
+PATH="$PATH:$mypath" CGO_ENABLED=1 CC=arm-linux-gnueabi-gcc \
+	GOOS=linux GOARCH=arm go run "$@"


### PR DESCRIPTION
"go run" supports running a simulator when GOOS/GOARCH is foreign
to the current system. This is normally achieved by -exec flag, but
go also looks for a specially named file, which we use.
See "go help run" for details.

This not only abstracts "build" phase from "exec", but also allows
cleaner operation, as all temporary files are managed by go tool.
