### PR TITLE
ssh: kill remote process when ^C

### DIFF
--- a/bin/go_linux_arm_exec
+++ b/bin/go_linux_arm_exec
@@ -6,7 +6,7 @@ shift
 remote_binary="/tmp/$(basename "$local_binary").$USER"
 
 echo "Copying $remote_binary..."
-gzip -c "$local_binary" | sudo -u pi -- ssh pi "
+gzip -c "$local_binary" | sudo -u pi -- ssh -t -t pi "
 	gzip -d >$remote_binary &&
 	chmod +x $remote_binary &&
 	echo 'Starting ${remote_binary}...' &&


### PR DESCRIPTION
When ^C'ing ssh, the remote process stays.
This might be a feature, but also a pain.
- shopt -s huponexit won't help (why?)
- allocating pseudo-tty worked
