### PR TITLE
Remove destination directory when deploying

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -36,8 +36,8 @@ deploy_ssh() {
 
 deploy_copy() {
 	if [ -d "${1?source required}" ]; then
-		tar cpf - -C "$(dirname "$1")" "$(basename "$1")" | \
-			deploy_ssh "cd ${2} && tar xf -"
+		tar -c -p -C "$(dirname "$1")" "$(basename "$1")" | \
+			deploy_ssh "cd ${2} && tar -x --unlink-first --recursive-unlink"
 	else
 		gzip -c "$1" | deploy_ssh "gzip -d >${2-~/$(basename "$1")}"
 	fi


### PR DESCRIPTION
There is garbage remaining after subsequent deployments
and never gets cleaned up.
This should make sure we delete "rover" directory before
creating a new one.